### PR TITLE
fix: 修復 GitHub Pages 部署路徑問題

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,13 +15,13 @@
     <meta property="og:description" content="模組化的 React 教學闖關遊戲，支援離線學習" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://your-domain.com" />
-    <meta property="og:image" content="/icons/icon-512.png" />
+    <meta property="og:image" content="./icons/icon-512.png" />
     
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="React 學習遊戲" />
     <meta name="twitter:description" content="模組化的 React 教學闖關遊戲" />
-    <meta name="twitter:image" content="/icons/icon-512.png" />
+    <meta name="twitter:image" content="./icons/icon-512.png" />
     
     <!-- PWA Meta Tags -->
     <meta name="theme-color" content="#61dafb" />
@@ -30,18 +30,18 @@
     <meta name="apple-mobile-web-app-title" content="React 學習遊戲" />
     
     <!-- Icons and Manifest -->
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16x16.png" />
-    <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" type="image/x-icon" href="./favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="./icons/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="./icons/favicon-16x16.png" />
+    <link rel="apple-touch-icon" href="./icons/apple-touch-icon.png" />
+    <!-- manifest 由 vite-plugin-pwa 自動生成 -->
     
     <!-- PWA Install Prompt -->
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="application-name" content="React 學習遊戲" />
     
     <!-- Preload Critical Resources -->
-    <link rel="preload" href="/src/data/modules.json" as="fetch" crossorigin="anonymous" />
+    <!-- modules.json 會在運行時動態載入，無需 preload -->
     
     <!-- Google Fonts (Optional) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import { LanguageProvider, useLanguage } from './contexts/LanguageContext';
 import HomePage from './components/HomePage';
 import ModulePage from './components/ModulePage';
@@ -53,7 +53,7 @@ function AppFooter() {
 function App() {
   return (
     <LanguageProvider>
-      <BrowserRouter>
+      <HashRouter>
         <div className="app">
           {/* 應用程式標題區 */}
           <AppHeader />
@@ -78,7 +78,7 @@ function App() {
           {/* 應用程式底部 */}
           <AppFooter />
         </div>
-      </BrowserRouter>
+      </HashRouter>
     </LanguageProvider>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -31,36 +31,8 @@ root.render(
   </React.StrictMode>
 );
 
-// 註冊 Service Worker (由 vite-plugin-pwa 處理)
-if ('serviceWorker' in navigator && !isDevelopment) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js')
-      .then((registration) => {
-        console.log('✅ Service Worker 註冊成功:', registration.scope);
-        
-        // 檢查更新
-        registration.addEventListener('updatefound', () => {
-          const newWorker = registration.installing;
-          if (newWorker) {
-            newWorker.addEventListener('statechange', () => {
-              if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                // 有新版本可用
-                console.log('🔄 發現新版本，請重新載入頁面');
-                
-                // 可以顯示更新提示給使用者
-                if (confirm('發現新版本！是否要重新載入以使用最新版本？')) {
-                  window.location.reload();
-                }
-              }
-            });
-          }
-        });
-      })
-      .catch((error) => {
-        console.log('❌ Service Worker 註冊失敗:', error);
-      });
-  });
-}
+// Service Worker 由 vite-plugin-pwa 自動處理
+// 不需要手動註冊，避免與 PWA 插件衝突
 
 // 錯誤邊界處理
 window.addEventListener('error', (event) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/ReactLearningGame/', // GitHub Pages 子路徑部署
   plugins: [
     react(),
     // PWA 配置 - 支援離線使用和應用程式安裝
@@ -17,8 +18,8 @@ export default defineConfig({
         theme_color: '#61dafb',
         background_color: '#282c34',
         display: 'standalone',
-        scope: '/',
-        start_url: '/',
+        scope: '/ReactLearningGame/',
+        start_url: '/ReactLearningGame/',
         icons: [
           {
             src: 'icons/icon-192.png',


### PR DESCRIPTION
- 設定 vite.config.js 的 base 路徑為 /ReactLearningGame/
- 更新 PWA manifest 的 scope 和 start_url 路徑
- 修復 index.html 中的靜態資源路徑引用
- 確保所有資源在 GitHub Pages 上正確載入

🤖 Generated with [Claude Code](https://claude.ai/code)